### PR TITLE
Update Taz Pro bltouch pinout in build-config.js 

### DIFF
--- a/config/examples/build-config.js
+++ b/config/examples/build-config.js
@@ -659,7 +659,14 @@ function make_config(PRINTER, TOOLHEAD) {
     if (IS_TAZ && !USE_ARCHIM2 && ["BLTouch", "Inductive"].includes(PROBE_STYLE)) {
         USE_LESS_MEMORY                                  = 2
     }
-
+    
+      if (PRINTER.includes("Quiver_TAZPro") && PRINTER.includes("BLTouch") && (!TOOLHEAD.includes("Quiver_DualExtruder"))) {
+        MARLIN["SERVO0_PIN"]                             = 21
+        MARLIN["SERVO1_PIN"]                             = 20
+        MARLIN["Z_MIN_PIN"]                              = 63
+        MARLIN["TEMP_1_PIN"]                             = -1
+        MARLIN["CALIBRATION_PIN"]                        = 31
+    }
 /*************************** GENERAL CONFIGURATION ***************************/
 
     MARLIN["STRING_CONFIG_H_AUTHOR"]                     = C_STRING("(Drunken Octopus Marlin)")


### PR DESCRIPTION
Makes it possible to connect the bltouch to the extruder 2 connections on the Taz Pro interface board.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description


Updated pins for the Taz Pro when using Bltouch.  The updated pins makes it possible to use the servo connector and extruder connector on the right side of the interface board.  The bltouch servo wires connect to the 3 pin servo connection and the z min wire connects to thermistor 2 connection.  
![IMG_2464 jpeg 600x0_q85](https://user-images.githubusercontent.com/57150638/236657324-26e75cc8-cb23-4b3f-b23e-b859900c5a1f.jpg)



### Requirements

Taz Pro, Bltouch and single tool head.

### Benefits

Makes it easier to connect bltouch to Taz pro.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
